### PR TITLE
TwoFactorFormListener: check if request has a session

### DIFF
--- a/Security/TwoFactor/Event/TwoFactorFormListener.php
+++ b/Security/TwoFactor/Event/TwoFactorFormListener.php
@@ -44,6 +44,10 @@ class TwoFactorFormListener implements EventSubscriberInterface
 
     public function onKernelRequest(RequestEvent $requestEvent): void
     {
+        if(!$requestEvent->getRequest()->hasSession()) {
+            return;
+        }
+        
         $token = $this->tokenStorage->getToken();
         if (!($token instanceof TwoFactorTokenInterface)) {
             return;


### PR DESCRIPTION
There could be situations where no session is given, in that case `$this->tokenStorage->getToken()` will throw an exception.
I think it would be better to just skip the handler in that case. 